### PR TITLE
feat(advanced): PER-8195 Phase 2 — advanced example for PercyXcui

### DIFF
--- a/.github/workflows/advanced.yml
+++ b/.github/workflows/advanced.yml
@@ -1,0 +1,44 @@
+name: Advanced — App Percy (XCUI)
+
+# PER-8195 Phase 2 — advanced example for PercyXcui.
+# Triggers manually only (`workflow_dispatch`). XCUI tests require a macOS
+# runner with Xcode + iOS Simulator.
+on:
+  workflow_dispatch:
+
+jobs:
+  advanced:
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Sanity-check Percy token
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+        run: |
+          if [ -z "$PERCY_TOKEN" ]; then
+            echo "::error::PERCY_TOKEN repo secret is required for the advanced XCUI job."
+            exit 1
+          fi
+      - name: Install @percy/cli
+        run: npm install --no-save @percy/cli@^1.31.13
+      - name: Boot iOS Simulator
+        run: |
+          xcrun simctl boot "iPhone 14" || true
+      - name: Run XCUI advanced tests on iOS Simulator
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PERCY_BRANCH: ${{ github.ref_name }}
+          PERCY_COMMIT: ${{ github.sha }}
+          PERCY_PROJECT: Percy XCUI Swift Advanced
+          PERCY_BUILD: Advanced XCUI
+        run: |
+          npx @percy/cli app:exec -- \
+            xcodebuild test \
+              -project 'Sample iOS.xcodeproj' \
+              -scheme 'Sample iOS' \
+              -destination 'platform=iOS Simulator,name=iPhone 14' \
+              -only-testing:SampleXCUITests/AdvancedScreenshotTests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # example-percy-xcui-swift
 Example app used by the [Percy XCUI Swift tutorial](https://docs.percy.io/v2-app/docs/xcuitest) demonstrating Percy's XCUI Swift integration.
 
+> **New:** This repo ships an [`advanced/`](./advanced) matrix + the corresponding `AdvancedScreenshotTests.swift` in `SampleXCUITests/`. XCUI tests must live under the test target, so the `advanced/` dir holds only matrix.yml and README. See the [Percy SDK Feature Matrix](https://docs.percy.io/docs/sdk-feature-matrix) for cross-SDK coverage.
+
+## Examples
+
+| Example | What it shows | Run command |
+|---|---|---|
+| `SampleXCUITests/SampleXCUITests.swift` (basic) | Minimum viable: `appPercy.screenshot(name:)` + a single `ScreenshotOptions` example. Start here. | Open `Sample iOS.xcodeproj` in Xcode and run the test suite. |
+| `SampleXCUITests/AdvancedScreenshotTests.swift` (advanced) | Full applicable App Percy XCUI SDK feature surface: nav + status bar heights, fullscreen, orientation (via `XCUIDevice.shared.orientation`), build metadata via env. See [`advanced/README.md`](./advanced/README.md). | `npx @percy/cli app:exec -- xcodebuild test -only-testing:SampleXCUITests/AdvancedScreenshotTests` |
+
 ## XCUI Swift Tutorial
 
 The tutorial assumes you're already familiar with XCUI and Swift and focuses on using it with App Percy. You'll still

--- a/SampleXCUITests/AdvancedScreenshotTests.swift
+++ b/SampleXCUITests/AdvancedScreenshotTests.swift
@@ -1,0 +1,51 @@
+// PER-8195 Phase 2 — XCUI advanced example.
+// Each XCTest case exercises one row of the App Percy / Appium Native matrix.
+// See ../advanced/matrix.yml for the canonical mapping.
+//
+// XCUI tests must live under a `*Tests` test target attached to the
+// Xcode project (SampleXCUITests). The sibling advanced/ directory holds
+// the matrix.yml + README that document this asymmetry.
+
+import XCTest
+import PercyXcui
+
+class AdvancedScreenshotTests: XCTestCase {
+    var appPercy: AppPercy!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        XCUIApplication().launch()
+        appPercy = AppPercy()
+    }
+
+    func testExercisesBaseline() {
+        try? appPercy.screenshot(name: "Sample iOS — baseline")
+    }
+
+    func testExercisesNavBarAndStatusBarHeight() {
+        var options = ScreenshotOptions()
+        options.navigationBarHeight = 100
+        options.statusBarHeight = 100
+        try? appPercy.screenshot(name: "Sample iOS — nav + status bar heights", options: options)
+    }
+
+    func testExercisesFullscreen() {
+        var options = ScreenshotOptions()
+        options.fullscreen = true
+        try? appPercy.screenshot(name: "Sample iOS — fullscreen", options: options)
+    }
+
+    func testExercisesOrientationLandscape() {
+        XCUIDevice.shared.orientation = .landscapeLeft
+        try? appPercy.screenshot(name: "Sample iOS — landscape")
+        XCUIDevice.shared.orientation = .portrait
+    }
+
+    func testExercisesBuildMetadataViaEnv() {
+        // PERCY_PROJECT / PERCY_BUILD / PERCY_BRANCH / PERCY_COMMIT are read
+        // by the AppPercy SDK at upload time via ProcessInfo.environment.
+        // This test documents the env-driven knobs; no per-call option needed.
+        try? appPercy.screenshot(name: "Sample iOS — build metadata via env")
+    }
+}

--- a/advanced/.percy.yml
+++ b/advanced/.percy.yml
@@ -1,0 +1,6 @@
+# PER-8195 — global config for PercyXcui advanced example.
+
+version: 2
+
+percy:
+  defer_uploads: false

--- a/advanced/README.md
+++ b/advanced/README.md
@@ -1,0 +1,47 @@
+# Advanced Percy + XCUI (Swift)
+
+This directory documents the advanced Percy SDK feature surface for `PercyXcui`. See the basic example at `SampleXCUITests/SampleXCUITests.swift` for the minimum integration.
+
+## Layout asymmetry
+
+XCUI tests must live under the Xcode test target (`SampleXCUITests/`) and be linked into `Sample iOS.xcodeproj` — they can't be relocated under `advanced/` without breaking the build. As a result, the advanced test code lives at:
+
+`SampleXCUITests/AdvancedScreenshotTests.swift`
+
+…while this `advanced/` directory holds only the `matrix.yml` (canonical row mapping) and this README. **You will also need to add `AdvancedScreenshotTests.swift` to the `SampleXCUITests` target in Xcode** — open `Sample iOS.xcodeproj`, select the file in the Project navigator, and check the `SampleXCUITests` checkbox in the File inspector.
+
+## What the advanced test covers
+
+5 XCTest cases in `AdvancedScreenshotTests.swift`:
+
+- `testExercisesBaseline` — bare screenshot
+- `testExercisesNavBarAndStatusBarHeight` — `ScreenshotOptions.navigationBarHeight` + `.statusBarHeight`
+- `testExercisesFullscreen` — `ScreenshotOptions.fullscreen`
+- `testExercisesOrientationLandscape` — `XCUIDevice.shared.orientation = .landscapeLeft`
+- `testExercisesBuildMetadataViaEnv` — `PERCY_PROJECT` / `PERCY_BUILD` / `PERCY_BRANCH` / `PERCY_COMMIT` read by the SDK at upload time
+
+Other native matrix rows (ignore/consider regions, sync, test_case, labels) are marked `Planned` in `matrix.yml` — `PercyXcui`'s `ScreenshotOptions` surface is narrower than the Appium SDK family.
+
+Web-only rows (widths, percyCSS, etc.) are marked `N/A`.
+
+## Run locally
+
+Requires Xcode + the Percy CLI:
+
+```bash
+export PERCY_TOKEN="<your project token>"
+npx @percy/cli@^1.31.13 app:exec -- \
+  xcodebuild test \
+    -project 'Sample iOS.xcodeproj' \
+    -scheme 'Sample iOS' \
+    -destination 'platform=iOS Simulator,name=iPhone 14' \
+    -only-testing:SampleXCUITests/AdvancedScreenshotTests
+```
+
+## CI note
+
+The advanced CI job is `workflow_dispatch`-only on `macos-latest` — XCUI tests require a macOS runner with Xcode + iOS Simulator. See `.github/workflows/advanced.yml`.
+
+## Coverage matrix
+
+States: `Covered` / `N/A — <reason>` / `Planned` / `Deprecated`. Source of truth is [`matrix.yml`](./matrix.yml).

--- a/advanced/matrix.yml
+++ b/advanced/matrix.yml
@@ -1,0 +1,86 @@
+# PER-8195 Phase 2 — XCUI-Swift matrix-row mapping.
+# Test code: ../SampleXCUITests/AdvancedScreenshotTests.swift
+#
+# XCUI tests must live under the test target (SampleXCUITests/), so they can't
+# be relocated under advanced/. This advanced/ directory holds matrix + README.
+
+sdk: xcui-swift
+package: PercyXcui
+language: swift
+cli_min_version: '1.31.13'
+
+rows:
+  - id: status_bar_height
+    state: covered
+    test: 'AdvancedScreenshotTests > testExercisesNavBarAndStatusBarHeight'
+  - id: nav_bar_height
+    state: covered
+    test: 'AdvancedScreenshotTests > testExercisesNavBarAndStatusBarHeight'
+  - id: fullscreen
+    state: covered
+    test: 'AdvancedScreenshotTests > testExercisesFullscreen'
+  - id: orientation_handling
+    state: covered
+    test: 'AdvancedScreenshotTests > testExercisesOrientationLandscape (XCUIDevice.shared.orientation)'
+
+  - id: build_metadata_via_env
+    state: covered
+    test: 'AdvancedScreenshotTests > testExercisesBuildMetadataViaEnv (SDK reads ProcessInfo.environment)'
+  - id: env_percy_branch
+    state: covered
+  - id: env_percy_commit
+    state: covered
+
+  # XCUI SDK exposes a narrow ScreenshotOptions surface — most Appium-style
+  # options are not available.
+  - id: device_name_override
+    state: n_a
+    reason: 'XCUI runs on a single simulator/device per session; device name implicit.'
+  - id: ignore_regions_xpaths
+    state: n_a
+    reason: 'Not exposed in PercyXcui ScreenshotOptions.'
+  - id: ignore_region_appium_elements
+    state: n_a
+    reason: 'XCUI uses XCUIElement, not Appium elements.'
+  - id: custom_ignore_regions
+    state: planned
+    test: 'Future: ScreenshotOptions ignore region API when exposed'
+  - id: consider_regions_xpaths
+    state: n_a
+    reason: 'Not exposed in PercyXcui.'
+  - id: sync
+    state: planned
+  - id: test_case
+    state: planned
+  - id: labels
+    state: planned
+
+  # Web-only.
+  - id: widths
+    state: n_a
+  - id: percy_css
+    state: n_a
+  - id: min_height
+    state: n_a
+  - id: enable_javascript
+    state: n_a
+  - id: scope
+    state: n_a
+  - id: discovery
+    state: n_a
+  - id: dom_transformation
+    state: n_a
+  - id: responsive_snapshot_capture
+    state: n_a
+  - id: readiness_preset
+    state: n_a
+  - id: device_pixel_ratio
+    state: n_a
+  - id: browsers
+    state: n_a
+
+  - id: percy_yml_global_config
+    state: covered
+  - id: environment_info_reporting
+    state: covered
+    test: 'automatic via PercyXcui client info'


### PR DESCRIPTION
## Summary
Adds an advanced XCUI example for `PercyXcui`. 5 XCTest cases in `AdvancedScreenshotTests.swift` exercising the `ScreenshotOptions` surface: `navigationBarHeight` + `statusBarHeight`, `fullscreen`, orientation via `XCUIDevice.shared.orientation`, baseline screenshot, build metadata via env.

## Layout asymmetry
XCUI tests must live under the test target (`SampleXCUITests/`) and be linked into `Sample iOS.xcodeproj` — they can't be relocated under `advanced/`. So:

- Test code → `SampleXCUITests/AdvancedScreenshotTests.swift`
- `advanced/` holds only `matrix.yml` + `README.md`.

**Maintainer action required:** After merging, open `Sample iOS.xcodeproj` in Xcode and add `AdvancedScreenshotTests.swift` to the `SampleXCUITests` target (check the target in the File inspector for the new file). Git tracks the file but not the Xcode project membership.

`PercyXcui` `ScreenshotOptions` surface is narrow — ignore/consider regions, sync, test_case, labels marked `Planned`. Web-only options marked `N/A`.

Issue: [PER-8195](https://browserstack.atlassian.net/browse/PER-8195). Parent: percy/percy-public-repos-parent#1.

## CI shape
`workflow_dispatch`-only on `macos-latest` — XCUI tests require Xcode + iOS Simulator.

## Test plan
- [ ] Maintainer adds the new file to the SampleXCUITests target in Xcode.
- [ ] Maintainer triggers `Advanced — App Percy (XCUI)` workflow manually with `PERCY_TOKEN` set.
- [ ] Verify a Percy build lands with the 5 advanced screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PER-8195]: https://browserstack.atlassian.net/browse/PER-8195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ